### PR TITLE
Fix PROMPT_CMD so it remembers the current working directory on OS X. Fix for #13

### DIFF
--- a/install.py
+++ b/install.py
@@ -14,7 +14,7 @@ import platform
 
 
 FUNCTION_CMD = 'function _update_ps1() {{ export PS1="$({}/promptastic.py $?)"; }}'
-PROMPT_CMD = 'export PROMPT_COMMAND="_update_ps1"'
+PROMPT_CMD = 'export PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"'
 
 
 class ConfigFile:


### PR DESCRIPTION
OS X has a file in `/etc/bashrc` that uses the variable PROMPT_COMMAND to set the `current working directory` when opening a new tab/window.

I don't know if Linux distros use it for the same purpose. But this PR fixes #13 on OS X, if this doesn't affect Linux Terminal, would you mind merging?